### PR TITLE
README: suggest `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Download latest release from the [Releases](https://github.com/elastic/elastic-p
 
 On macOS, use `xattr -r -d com.apple.quarantine elastic-package` after downloading to allow the binary to run.
 
-Alternatively, you may use `go get` but you will not be able to use the `elastic-package version` command or check updates.
+Alternatively, you may use `go install` but you will not be able to use the `elastic-package version` command or check updates.
 
 ```bash
-go get github.com/elastic/elastic-package
+go install github.com/elastic/elastic-package@latest
 ```
 
 _Please make sure that you've correctly [setup environment variables](https://golang.org/doc/gopath_code.html#GOPATH) -


### PR DESCRIPTION
When following the instructions in the README, I noticed this deprecation message:

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```

This PR suggests `go install` instead.